### PR TITLE
处理 MySQL unsigned 整数类型的 PostgreSQL 转换

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.wz2cool</groupId>
     <artifactId>canal-utils</artifactId>
-    <version>0.2.17</version>
+    <version>0.2.18</version>
     <packaging>jar</packaging>
 
     <organization>

--- a/src/main/java/com/github/wz2cool/canal/utils/converter/mysql/MysqlAlterSqlConverter.java
+++ b/src/main/java/com/github/wz2cool/canal/utils/converter/mysql/MysqlAlterSqlConverter.java
@@ -13,10 +13,9 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * MySQL alter SQL converter.
- * Handles ALTER operations with optional decorators.
+ * MySQL alter 语句转换装饰器
  *
- * @author penghai
+ * @author YinPenghai
  */
 public class MysqlAlterSqlConverter extends BaseAlterSqlConverter {
     private final MysqlColDataTypeConverter mysqlColDataTypeConverter = new MysqlColDataTypeConverter();

--- a/src/main/java/com/github/wz2cool/canal/utils/converter/mysql/MysqlAlterSqlConverter.java
+++ b/src/main/java/com/github/wz2cool/canal/utils/converter/mysql/MysqlAlterSqlConverter.java
@@ -59,54 +59,44 @@ public class MysqlAlterSqlConverter extends BaseAlterSqlConverter {
     }
 
     private Optional<String> generateSql(String action, AlterColumnExpression alterColumnExpression) {
-        SqlContext sqlContext = new SqlContext(
-                action,
-                "",
-                alterColumnExpression.getTableName(),
-                alterColumnExpression.getColOldName(),
-                alterColumnExpression.getColumnName(),
-                getFormattedDataType(alterColumnExpression),
-                alterColumnExpression.getNullAble(),
-                "",
-                alterColumnExpression.getCommentText()
-        );
+        SqlContext sqlContext = new SqlContext.Builder()
+                .action(action)
+                .schemaName("")
+                .tableName(alterColumnExpression.getTableName())
+                .oldColumnName(alterColumnExpression.getColOldName())
+                .newColumnName(alterColumnExpression.getColumnName())
+                .dataTypeString(getFormattedDataType(alterColumnExpression))
+                .nullAble(alterColumnExpression.getNullAble())
+                .defaultValue("")
+                .commentText(alterColumnExpression.getCommentText())
+                .build();
 
         for (AlterSqlConverterDecorator decorator : decorators) {
             sqlContext = decorator.apply(this, alterColumnExpression, sqlContext);
         }
 
-        return Optional.of(generateColumnSql(
-                sqlContext.action,
-                sqlContext.schemaName,
-                sqlContext.tableName,
-                sqlContext.oldColumnName,
-                sqlContext.newColumnName,
-                sqlContext.dataTypeString,
-                sqlContext.nullAble,
-                sqlContext.defaultValue,
-                sqlContext.commentText
-        ));
+        return Optional.of(generateColumnSql(sqlContext));
     }
 
     private Optional<String> generateDropColumnSql(AlterColumnExpression alterColumnExpression) {
-        SqlContext sqlContext = new SqlContext(
-                "DROP",
-                "",
-                alterColumnExpression.getTableName(),
-                alterColumnExpression.getColumnName(),
-                null,
-                null,
-                null,
-                null,
-                null
-        );
+        SqlContext sqlContext = new SqlContext.Builder()
+                .action("DROP")
+                .schemaName("")
+                .tableName(alterColumnExpression.getTableName())
+                .oldColumnName(alterColumnExpression.getColumnName())
+                .newColumnName(null)
+                .dataTypeString(null)
+                .nullAble(null)
+                .defaultValue(null)
+                .commentText(null)
+                .build();
 
         for (AlterSqlConverterDecorator decorator : decorators) {
             sqlContext = decorator.apply(this, alterColumnExpression, sqlContext);
         }
 
-        String qualifiedTableName = getQualifiedTableName(sqlContext.schemaName, sqlContext.tableName);
-        String formattedColumnName = getFormattedColumnNameOrEmpty(sqlContext.oldColumnName);
+        String qualifiedTableName = getQualifiedTableName(sqlContext.getSchemaName(), sqlContext.getTableName());
+        String formattedColumnName = getFormattedColumnNameOrEmpty(sqlContext.getOldColumnName());
         String sql = String.format("ALTER TABLE %s DROP COLUMN %s;", qualifiedTableName, formattedColumnName).trim();
         return Optional.of(sql);
     }
@@ -116,9 +106,16 @@ public class MysqlAlterSqlConverter extends BaseAlterSqlConverter {
         return new ArrayList<>();
     }
 
-    protected String generateColumnSql(String action, String schemaName, String tableName, String oldColumnName, String newColumnName,
-                                       String dataTypeString,
-                                       String nullAble, String defaultValue, String commentText) {
+    protected String generateColumnSql(SqlContext sqlContext) {
+        final String action = sqlContext.getAction();
+        final String schemaName = sqlContext.getSchemaName();
+        final String tableName = sqlContext.getTableName();
+        final String oldColumnName = sqlContext.getOldColumnName();
+        final String newColumnName = sqlContext.getNewColumnName();
+        final String dataTypeString = sqlContext.getDataTypeString();
+        final String nullAble = sqlContext.getNullAble();
+        final String defaultValue = sqlContext.getDefaultValue();
+        final String commentText = sqlContext.getCommentText();
         String qualifiedTableName = getQualifiedTableName(schemaName, tableName);
         String formattedOldColumnName = getFormattedColumnNameOrEmpty(oldColumnName);
         String formattedNewColumnName = getFormattedColumnNameOrEmpty(newColumnName);

--- a/src/main/java/com/github/wz2cool/canal/utils/converter/mysql/decorator/AlterSqlConverterDecorator.java
+++ b/src/main/java/com/github/wz2cool/canal/utils/converter/mysql/decorator/AlterSqlConverterDecorator.java
@@ -5,7 +5,7 @@ import com.github.wz2cool.canal.utils.model.SqlContext;
 import com.github.wz2cool.canal.utils.model.AlterColumnExpression;
 
 /**
- * alter sql converter decorator
+ * alter 语句转换装饰器
  * @author YinPengHai
  */
 public interface AlterSqlConverterDecorator {

--- a/src/main/java/com/github/wz2cool/canal/utils/converter/mysql/decorator/DefaultValueDecorator.java
+++ b/src/main/java/com/github/wz2cool/canal/utils/converter/mysql/decorator/DefaultValueDecorator.java
@@ -13,20 +13,11 @@ public class DefaultValueDecorator implements AlterSqlConverterDecorator {
 
     @Override
     public SqlContext apply(BaseAlterSqlConverter converter, AlterColumnExpression alterColumnExpression, SqlContext sqlContext) {
-        SqlContext newSqlContext = new SqlContext(
-                sqlContext.action,
-                sqlContext.schemaName,
-                sqlContext.tableName,
-                sqlContext.oldColumnName,
-                sqlContext.newColumnName,
-                sqlContext.dataTypeString,
-                sqlContext.nullAble,
-                sqlContext.defaultValue,
-                sqlContext.commentText
-        );
         if (StringUtils.isNotBlank(alterColumnExpression.getDefaultValue())) {
-            newSqlContext.defaultValue = DEFAULT + alterColumnExpression.getDefaultValue();
+            return SqlContext.from(sqlContext)
+                    .defaultValue(DEFAULT + alterColumnExpression.getDefaultValue())
+                    .build();
         }
-        return newSqlContext;
+        return sqlContext;
     }
 }

--- a/src/main/java/com/github/wz2cool/canal/utils/converter/mysql/decorator/ReplaceNameDecorator.java
+++ b/src/main/java/com/github/wz2cool/canal/utils/converter/mysql/decorator/ReplaceNameDecorator.java
@@ -19,16 +19,9 @@ public class ReplaceNameDecorator implements AlterSqlConverterDecorator {
 
     @Override
     public SqlContext apply(BaseAlterSqlConverter converter, AlterColumnExpression alterColumnExpression, SqlContext sqlContext) {
-        return new SqlContext(
-                sqlContext.action,
-                targetSchemaName,
-                targetTableName,
-                sqlContext.oldColumnName,
-                sqlContext.newColumnName,
-                sqlContext.dataTypeString,
-                sqlContext.nullAble,
-                sqlContext.defaultValue,
-                sqlContext.commentText
-        );
+       return SqlContext.from(sqlContext)
+                .schemaName(targetSchemaName)
+                .tableName(targetTableName)
+                .build();
     }
 }

--- a/src/main/java/com/github/wz2cool/canal/utils/converter/postgresql/PostgresqlAlterSqlConverter.java
+++ b/src/main/java/com/github/wz2cool/canal/utils/converter/postgresql/PostgresqlAlterSqlConverter.java
@@ -12,9 +12,9 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * PostgreSQL alter sql converter.
+ * PostgreSQL alter 语句转换器
  *
- * @author YinPengHai
+ *@author YinPenghai
  **/
 public class PostgresqlAlterSqlConverter extends BaseAlterSqlConverter {
     private final PostgresqlColDataTypeConverter postgresqlColDataTypeConverter = new PostgresqlColDataTypeConverter();

--- a/src/main/java/com/github/wz2cool/canal/utils/converter/postgresql/PostgresqlAlterSqlConverter.java
+++ b/src/main/java/com/github/wz2cool/canal/utils/converter/postgresql/PostgresqlAlterSqlConverter.java
@@ -60,37 +60,32 @@ public class PostgresqlAlterSqlConverter extends BaseAlterSqlConverter {
     }
 
     private Optional<String> generateSql(String action, AlterColumnExpression alterColumnExpression) {
-        SqlContext sqlContext = new SqlContext(
-                action,
-                "",
-                alterColumnExpression.getTableName(),
-                alterColumnExpression.getColOldName(),
-                alterColumnExpression.getColumnName(),
-                alterColumnExpression.getColDataType() != null ? getDataTypeString(alterColumnExpression.getColDataType()) : "",
-                alterColumnExpression.getNullAble(),
-                alterColumnExpression.getDefaultValue(),
-                alterColumnExpression.getCommentText());
-
+        SqlContext sqlContext = new SqlContext.Builder()
+                .action( action)
+                .schemaName("")
+                .tableName(alterColumnExpression.getTableName())
+                .oldColumnName(alterColumnExpression.getColOldName())
+                .newColumnName(alterColumnExpression.getColumnName())
+                .dataTypeString(alterColumnExpression.getColDataType() != null ? getDataTypeString(alterColumnExpression.getColDataType()) : "")
+                .nullAble(alterColumnExpression.getNullAble())
+                .defaultValue(alterColumnExpression.getDefaultValue())
+                .commentText(alterColumnExpression.getCommentText())
+                .build();
         for (AlterSqlConverterDecorator decorator : decorators) {
             sqlContext = decorator.apply(this, alterColumnExpression, sqlContext);
         }
 
-        return Optional.of(generateColumnSql(
-                sqlContext.action,
-                sqlContext.schemaName,
-                sqlContext.tableName,
-                sqlContext.oldColumnName,
-                sqlContext.newColumnName,
-                sqlContext.dataTypeString,
-                sqlContext.nullAble,
-                sqlContext.defaultValue,
-                sqlContext.commentText));
+        return Optional.of(generateColumnSql(sqlContext));
     }
 
-    protected String generateColumnSql(String action, String schemaName, String tableName, String oldColumnName, String newColumnName,
-                                       String dataTypeString,
-                                       String nullAble, String defaultValue, String usingGrammar) {
-        String qualifiedTableName = getQualifiedTableName(schemaName, tableName);
+    protected String generateColumnSql(SqlContext sqlContext) {
+        final String action = sqlContext.getAction();
+        final String schemaName = sqlContext.getSchemaName();
+        final String tableName = sqlContext.getTableName();
+        final String oldColumnName = sqlContext.getOldColumnName();
+        final String newColumnName = sqlContext.getNewColumnName();
+        final String dataTypeString = sqlContext.getDataTypeString();
+        final String qualifiedTableName = getQualifiedTableName(schemaName, tableName);
         if ("ADD".equals(action)) {
             return String.format("ALTER TABLE %s %s %s %s",
                     qualifiedTableName,

--- a/src/main/java/com/github/wz2cool/canal/utils/converter/postgresql/PostgresqlAlterSqlConverter.java
+++ b/src/main/java/com/github/wz2cool/canal/utils/converter/postgresql/PostgresqlAlterSqlConverter.java
@@ -98,7 +98,10 @@ public class PostgresqlAlterSqlConverter extends BaseAlterSqlConverter {
                     action,
                     oldColumnName,
                     newColumnName);
-            String alterColumnTypeSql = alterColumnType(qualifiedTableName, sqlContext);
+            SqlContext sqlContextCopy = SqlContext.from(sqlContext)
+                    .action("ALTER")
+                    .build();
+            String alterColumnTypeSql = alterColumnType(qualifiedTableName, sqlContextCopy);
             return String.format("%s__SPLIT__%s", renameSql, alterColumnTypeSql);
         } else if ("DROP".equals(action)) {
             return String.format("ALTER TABLE %s %s COLUMN %s",

--- a/src/main/java/com/github/wz2cool/canal/utils/converter/postgresql/PostgresqlAlterSqlConverter.java
+++ b/src/main/java/com/github/wz2cool/canal/utils/converter/postgresql/PostgresqlAlterSqlConverter.java
@@ -86,7 +86,6 @@ public class PostgresqlAlterSqlConverter extends BaseAlterSqlConverter {
         final String tableName = sqlContext.getTableName();
         final String oldColumnName = sqlContext.getOldColumnName();
         final String newColumnName = sqlContext.getNewColumnName();
-        final String dataTypeString = sqlContext.getDataTypeString();
         final String qualifiedTableName = getQualifiedTableName(schemaName, tableName);
         if ("ADD".equals(action)) {
             return addColumn(qualifiedTableName, sqlContext);

--- a/src/main/java/com/github/wz2cool/canal/utils/generator/AbstractSqlTemplateGenerator.java
+++ b/src/main/java/com/github/wz2cool/canal/utils/generator/AbstractSqlTemplateGenerator.java
@@ -102,12 +102,19 @@ public abstract class AbstractSqlTemplateGenerator {
             String alterSql = alterSqlOptional.get();
             List<String> alterSqlList = getAlterSqlConverter().convert(alterSql);
             for (String s : alterSqlList) {
-                SqlTemplate sqlTemplate = new SqlTemplate();
-                sqlTemplate.setExpression(s);
-                result.add(sqlTemplate);
+                String[] sqlArray = splitSqlIfNecessary(s);
+                for (String sql : sqlArray) {
+                    SqlTemplate sqlTemplate = new SqlTemplate();
+                    sqlTemplate.setExpression(sql);
+                    result.add(sqlTemplate);
+                }
             }
         }
         return result;
+    }
+
+    private String[] splitSqlIfNecessary(String s) {
+        return s.split("__SPLIT__");
     }
 
     /**

--- a/src/main/java/com/github/wz2cool/canal/utils/model/SqlContext.java
+++ b/src/main/java/com/github/wz2cool/canal/utils/model/SqlContext.java
@@ -1,30 +1,83 @@
 package com.github.wz2cool.canal.utils.model;
 
-/**
- * sql context
- * @author YinPengHai
- **/
 public class SqlContext {
-    public String schemaName;
-    public String tableName;
-    public String defaultValue;
-    public String action;
-    public String oldColumnName;
-    public String newColumnName;
-    public String dataTypeString;
-    public String nullAble;
-    public String commentText;
+    private final String schemaName;
+    private final String tableName;
+    private final String defaultValue;
+    private final String action;
+    private final String oldColumnName;
+    private final String newColumnName;
+    private final String dataTypeString;
+    private final String nullAble;
+    private final String commentText;
+    private final Boolean unsignedFlag;
 
-    public SqlContext(String action, String schemaName, String tableName, String oldColumnName, String newColumnName,
-                      String dataTypeString, String nullAble, String defaultValue, String commentText) {
-        this.action = action;
-        this.schemaName = schemaName;
-        this.tableName = tableName;
-        this.oldColumnName = oldColumnName;
-        this.newColumnName = newColumnName;
-        this.dataTypeString = dataTypeString;
-        this.nullAble = nullAble;
-        this.defaultValue = defaultValue;
-        this.commentText = commentText;
+    private SqlContext(Builder builder) {
+        this.action = builder.action;
+        this.schemaName = builder.schemaName;
+        this.tableName = builder.tableName;
+        this.oldColumnName = builder.oldColumnName;
+        this.newColumnName = builder.newColumnName;
+        this.dataTypeString = builder.dataTypeString;
+        this.nullAble = builder.nullAble;
+        this.defaultValue = builder.defaultValue;
+        this.commentText = builder.commentText;
+        this.unsignedFlag = builder.unsignedFlag;
+    }
+
+    // Getter 方法
+    public String getSchemaName() { return schemaName; }
+    public String getTableName() { return tableName; }
+    public String getDefaultValue() { return defaultValue; }
+    public String getAction() { return action; }
+    public String getOldColumnName() { return oldColumnName; }
+    public String getNewColumnName() { return newColumnName; }
+    public String getDataTypeString() { return dataTypeString; }
+    public String getNullAble() { return nullAble; }
+    public String getCommentText() { return commentText; }
+    public Boolean getUnsignedFlag() { return unsignedFlag; }
+
+    // Builder 内部类
+    public static class Builder {
+        private String schemaName;
+        private String tableName;
+        private String defaultValue;
+        private String action;
+        private String oldColumnName;
+        private String newColumnName;
+        private String dataTypeString;
+        private String nullAble;
+        private String commentText;
+        private Boolean unsignedFlag;
+
+        public Builder schemaName(String schemaName) { this.schemaName = schemaName; return this; }
+        public Builder tableName(String tableName) { this.tableName = tableName; return this; }
+        public Builder defaultValue(String defaultValue) { this.defaultValue = defaultValue; return this; }
+        public Builder action(String action) { this.action = action; return this; }
+        public Builder oldColumnName(String oldColumnName) { this.oldColumnName = oldColumnName; return this; }
+        public Builder newColumnName(String newColumnName) { this.newColumnName = newColumnName; return this; }
+        public Builder dataTypeString(String dataTypeString) { this.dataTypeString = dataTypeString; return this; }
+        public Builder nullAble(String nullAble) { this.nullAble = nullAble; return this; }
+        public Builder commentText(String commentText) { this.commentText = commentText; return this; }
+        public Builder unsignedFlag(Boolean unsignedFlag) { this.unsignedFlag = unsignedFlag; return this; }
+
+        public SqlContext build() {
+            return new SqlContext(this);
+        }
+    }
+
+    // 从已有对象生成 Builder
+    public static Builder from(SqlContext other) {
+        return new Builder()
+                .action(other.action)
+                .schemaName(other.schemaName)
+                .tableName(other.tableName)
+                .oldColumnName(other.oldColumnName)
+                .newColumnName(other.newColumnName)
+                .dataTypeString(other.dataTypeString)
+                .nullAble(other.nullAble)
+                .defaultValue(other.defaultValue)
+                .commentText(other.commentText)
+                .unsignedFlag(other.unsignedFlag);
     }
 }

--- a/src/main/java/com/github/wz2cool/canal/utils/model/SqlContext.java
+++ b/src/main/java/com/github/wz2cool/canal/utils/model/SqlContext.java
@@ -1,5 +1,9 @@
 package com.github.wz2cool.canal.utils.model;
 
+/**
+ * sql上下文
+ * @author YinPenghai
+ */
 public class SqlContext {
     private final String schemaName;
     private final String tableName;

--- a/src/test/java/com/github/wz2cool/canal/utils/genertor/PostgresqlSqlTemplateGeneratorTest.java
+++ b/src/test/java/com/github/wz2cool/canal/utils/genertor/PostgresqlSqlTemplateGeneratorTest.java
@@ -45,5 +45,18 @@ public class PostgresqlSqlTemplateGeneratorTest {
         Assert.assertEquals(expectedSql, sqlTemplate.getExpression());
     }
 
+    @Test
+    public void testAlterColumnWithUnsigned() throws JSQLParserException {
+        canalRowChange.setSql("ALTER TABLE `penghai_test`.`bank_product_site_config` change test4 test6 int(11) unsigned null");
+        final List<SqlTemplate> sqlTemplates = postgresqlSqlTemplateGenerator.listDDLSqlTemplates(canalRowChange);
+        SqlTemplate sqlTemplate = sqlTemplates.get(0);
+        String expectedSql = "ALTER TABLE hermes_test.\"test_bond_quote_best_price_broker\" RENAME COLUMN test4 TO test6";
+        Assert.assertEquals(expectedSql, sqlTemplate.getExpression());
+
+        SqlTemplate sqlTemplate2 = sqlTemplates.get(1);
+        String expectedSql2 = "ALTER TABLE hermes_test.\"test_bond_quote_best_price_broker\" ALTER COLUMN test6 TYPE bigint USING test6::bigint";
+        Assert.assertEquals(expectedSql2, sqlTemplate2.getExpression());
+    }
+
 
 }


### PR DESCRIPTION
1. 代码结构优化

- 使用 Builder 模式 重构 SqlContext 构造与创建，减少长参数构造器，提高可读性和可扩展性。

2. MySQL unsigned 类型适配

- 当 MySQL 字段为 INT UNSIGNED → PostgreSQL BIGINT

- 当 MySQL 字段为 SMALLINT UNSIGNED → PostgreSQL INT

- 避免 PostgreSQL 数据溢出问题。

3. ALTER SQL 生成优化

针对 MySQL ALTER 语句 同时修改字段名和字段类型 的场景，生成 PostgreSQL SQL 时拆分成 两条语句：

- 先修改字段名

- 再修改字段类型
